### PR TITLE
Fix Compile Error with LuaJIT

### DIFF
--- a/mp.c
+++ b/mp.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #if LUA_VERSION_NUM == 501
 # define LUA_OK 0


### PR DESCRIPTION
Hi, when I compile lua-mp with LuaJIT, I get a compile error from GCC 15:

```
mp.c:169:39: error: ‘CHAR_BIT’ undeclared here (not in a function)
  169 |     unsigned len : sizeof(unsigned) * CHAR_BIT - 1;
      |                                       ^~~~~~~~
mp.c:7:1: note: ‘CHAR_BIT’ is defined in header ‘<limits.h>’; this is probably fixable by adding ‘#include <limits.h>’
    6 | #include <string.h>
  +++ |+#include <limits.h>
    7 | 
mp.c:169:14: error: bit-field ‘len’ width not an integer constant
  169 |     unsigned len : sizeof(unsigned) * CHAR_BIT - 1;
      |              ^~~
```

It works with PUC Lua because luaconf.h includes limits.h, but LuaJIT's luaconf.h does not include it.